### PR TITLE
Refactor staff service methods and mappings

### DIFF
--- a/src/HA_ERP.Application.Contracts/Staffs/IStaffAppService.cs
+++ b/src/HA_ERP.Application.Contracts/Staffs/IStaffAppService.cs
@@ -14,8 +14,9 @@ namespace HA_ERP.Staffs
 
         Task<PagedResultDto<StaffDto>> GetListAsync();
 
-        Task<PagedResultDto<StaffSimpleDto>> GetListByOrganizationAsync(int id, PagedAndSortedResultRequestDto input);
+        Task<PagedResultDto<StaffDto>> GetListByOrganizationAsync(int id, PagedAndSortedResultRequestDto input);
 
+        Task <List<StaffSimpleDto>> GetManager(int id);
 
         Task<StaffDto> CreateAsync(CreateStaffDto input);
 

--- a/src/HA_ERP.Application/HA_ERPApplicationAutoMapperProfile.cs
+++ b/src/HA_ERP.Application/HA_ERPApplicationAutoMapperProfile.cs
@@ -15,6 +15,7 @@ public class HA_ERPApplicationAutoMapperProfile : Profile
         CreateMap<Staff, StaffDto>().ReverseMap();
         CreateMap<CreateStaffDto, Staff>().ReverseMap();
         CreateMap<UpdateStaffDto, Staff>().ReverseMap();
+        CreateMap<StaffSimpleDto, Staff>().ReverseMap();
 
 
         CreateMap<Organization, OrganizationDto>().ReverseMap();

--- a/src/HA_ERP.Application/Staffs/StaffAppService.cs
+++ b/src/HA_ERP.Application/Staffs/StaffAppService.cs
@@ -1,9 +1,10 @@
+using HA_ERP.Permissions;
+using Microsoft.AspNetCore.Authorization;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using HA_ERP.Permissions;
-using Microsoft.AspNetCore.Authorization;
 using Volo.Abp.Application.Dtos;
+using Volo.Abp.ObjectMapping;
 
 
 namespace HA_ERP.Staffs
@@ -53,7 +54,25 @@ namespace HA_ERP.Staffs
             return new PagedResultDto<StaffDto>(totalCount, staffDtoList);
         }
 
+        public async Task<PagedResultDto<StaffDto>> GetListByOrganizationAsync(int id, PagedAndSortedResultRequestDto input)
+        {
+            var staffList = await _staffRepository.GetListAsync(a => a.OrganizationId == id);
+            
+            var staffDtoList = ObjectMapper.Map<List<Staff>, List<StaffDto>>(staffList);
+
+            var totalCount = staffDtoList.Count;
+
+            return new PagedResultDto<StaffDto>(totalCount, staffDtoList);
+        }
+
        
+        public async Task<List<StaffSimpleDto>> GetManager(int id)
+        {
+            var staffs = await _staffRepository.GetStaffsWithManagerRoleAsync(id);
+
+            return ObjectMapper.Map<List<Staff>, List<StaffSimpleDto>>(staffs);
+        }
+
         [Authorize(HA_ERPPermissions.Staffs.Update)]
         public async Task UpdateAsync(int id, UpdateStaffDto input)
         {
@@ -66,27 +85,6 @@ namespace HA_ERP.Staffs
             await _staffRepository.UpdateAsync(staff);
         }
 
-        public async Task<PagedResultDto<StaffSimpleDto>> GetListByOrganizationAsync(int id, PagedAndSortedResultRequestDto input)
-        {
-            var staffs = await _staffRepository.GetStaffsWithManagerRoleAsync();
-
-            var filtered = staffs.Where(x => x.OrganizationId == id);
-
-            var totalCount = filtered.Count();
-
-            var items = filtered
-                .Skip(input.SkipCount)
-                .Take(input.MaxResultCount)
-                .Select(x => new StaffSimpleDto
-                {
-                    Id = x.Id,
-                    Name = x.Name
-                })
-                .ToList();
-
-            return new PagedResultDto<StaffSimpleDto>(totalCount, items);
-        }
-
-
+       
     }
 }

--- a/src/HA_ERP.Domain/Staffs/IStaffRepository.cs
+++ b/src/HA_ERP.Domain/Staffs/IStaffRepository.cs
@@ -9,6 +9,6 @@ namespace HA_ERP.Staffs
 {
     public interface IStaffRepository : IRepository<Staff, int>
     {
-        Task<List<Staff>> GetStaffsWithManagerRoleAsync();
+        Task<List<Staff>> GetStaffsWithManagerRoleAsync(int id);
     }
 }

--- a/src/HA_ERP.EntityFrameworkCore/Staffs/EfCoreStaffRepository.cs
+++ b/src/HA_ERP.EntityFrameworkCore/Staffs/EfCoreStaffRepository.cs
@@ -20,7 +20,7 @@ namespace HA_ERP.Staffs
 
         }
 
-        public async Task<List<Staff>> GetStaffsWithManagerRoleAsync()
+        public async Task<List<Staff>> GetStaffsWithManagerRoleAsync(int id)
         {
             var dbContext = await GetDbContextAsync();
 
@@ -40,7 +40,7 @@ namespace HA_ERP.Staffs
                 from staff in dbContext.Staffs
                 join user in dbContext.Users on staff.UserId equals user.Id
                 join userRole in dbContext.UserRoles on user.Id equals userRole.UserId
-                where userRole.RoleId == managerRoleId
+                where userRole.RoleId == managerRoleId && staff.OrganizationId == id
                 select staff
             ).ToListAsync();
 


### PR DESCRIPTION
- Updated `GetListByOrganizationAsync` to return `PagedResultDto<StaffDto>` instead of `PagedResultDto<StaffSimpleDto>`.
- Added `GetManager` method to `IStaffAppService` for fetching staff with manager roles.
- Introduced mapping for `StaffSimpleDto` in `HA_ERPApplicationAutoMapperProfile`.
- Removed old implementation of `GetListByOrganizationAsync` in `StaffAppService.cs`.
- Modified `GetStaffsWithManagerRoleAsync` in `IStaffRepository` to accept an organization ID.
- Updated `EfCoreStaffRepository` to filter staff by organization ID in the manager role query.